### PR TITLE
Standardize redirects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   - cd test-root
   - root=`pwd`
   - drush dl ctools psr0 views webform
-  - drush --yes pm-enable little_helpers webform
+  - drush --yes pm-enable little_helpers little_helpers_test webform
 
 script:
   - cd $repo

--- a/little_helpers.module
+++ b/little_helpers.module
@@ -1,7 +1,50 @@
 <?php
 
-use \Drupal\little_helpers\Webform\Webform;
-use \Drupal\little_helpers\Webform\Submission;
+/**
+ * @file
+ * Hook implementations and supplementary functions availably in any request.
+ */
+
+use Drupal\little_helpers\System\FormRedirect;
+use Drupal\little_helpers\Webform\Webform;
+use Drupal\little_helpers\Webform\Submission;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for webform_client_form().
+ *
+ * Insert a custom submit handler that lets other modules alter the redirect.
+ */
+function little_helpers_form_webform_client_form_alter(array &$form, array &$form_state) {
+  $form['#submit'][] = '_little_helpers_webform_redirect_alter';
+}
+
+/**
+ * Form submission handler: Let other modules alter the redirect.
+ *
+ * @see little_helpers_form_webform_client_form_alter()
+ * @see hook_webform_redirect_alter()
+ */
+function _little_helpers_webform_redirect_alter(array $form, array &$form_state) {
+  if (!$form_state['webform_completed'] || !$form_state['redirect']) {
+    return;
+  }
+
+  $sid = $form_state['values']['details']['sid'];
+  $submission = Submission::load($form['#node']->nid, $sid);
+  $redirect = FormRedirect::fromFormStateRedirect($form_state['redirect']);
+  drupal_alter('webform_redirect', $redirect, $submission);
+  $form_state['redirect'] = $redirect->toFormStateRedirect();
+}
+
+/**
+ * Implements hook_webform_confirm_email_confirmation_redirect_alter().
+ */
+function little_helpers_webform_confirm_email_confirmation_redirect_alter(&$redirect, $node, $submission) {
+  $submission = new Submission($node, $submission);
+  $r = FormRedirect::fromFormStateRedirect($redirect);
+  drupal_alter('webform_redirect', $r, $submission);
+  $redirect = $r->toFormStateRedirect();
+}
 
 /**
  * Implements hook_webform_submission_insert().

--- a/little_helpers_test/little_helpers_test.info
+++ b/little_helpers_test/little_helpers_test.info
@@ -1,0 +1,5 @@
+name = Little helpers test module
+description = This is used for testing only.
+core = 7.x
+package = Other
+hidden = TRUE

--- a/little_helpers_test/little_helpers_test.module
+++ b/little_helpers_test/little_helpers_test.module
@@ -1,0 +1,17 @@
+<?php
+
+use Drupal\little_helpers\System\FormRedirect;
+use Drupal\little_helpers\Webform\Submission;
+
+/**
+ * Test hook implementations.
+ * @file
+ */
+
+/**
+ * Implements hook_webform_redirect_alter().
+ */
+function little_helpers_test_webform_redirect_alter(FormRedirect $redirect, Submission $submission = NULL) {
+  $redirect->query['test'] = 'foo';
+  $redirect->fragment .= 'bar';
+}

--- a/src/System/FormRedirect.php
+++ b/src/System/FormRedirect.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\little_helpers\System;
+
+/**
+ * Standardized data-structure for form redirects.
+ *
+ * Form redirects can be either a string URL or a numeric array with the two
+ * arguments for `url()`. This class encapsulates this data-structure into
+ * something that can be handled more easily.
+ */
+class FormRedirect {
+
+  public $path;
+  public $query = [];
+  public $fragment = '';
+
+  /**
+   * Create redirect object from an array of options.
+   */
+  public function __construct($data) {
+    foreach ($data as $k => $v) {
+      $this->{$k} = $v;
+    }
+  }
+
+  /**
+   * Create a redirect based on a $form_state['redirect'].
+   *
+   * @param mixed $redirect
+   *   Either a string URL or an array with up to two elements:
+   *   - The path.
+   *   - Additional options for the `url()` function.
+   */
+  public static function fromFormStateRedirect($redirect) {
+    if (!$redirect) {
+      $data = ['path' => NULL];
+    }
+    elseif (is_array($redirect)) {
+      $data = ['path' => $redirect[0]];
+      if (isset($redirect[1])) {
+        $data += $redirect[1];
+      }
+    }
+    else {
+      $data = drupal_parse_url($redirect);
+    }
+    return new static($data);
+  }
+
+  /**
+   * Generate a $form_state['redirect'] compatible version of this redirect.
+   *
+   * @return null|array
+   *   Array with two elements:
+   *   1. The path.
+   *   2. Additional options.
+   *   … or NULL if the path is NULL.
+   */
+  public function toFormStateRedirect() {
+    if (is_null($this->path)) {
+      return NULL;
+    }
+    $options = (array) $this;
+    unset($options['path']);
+    return [$this->path, $options];
+  }
+
+}

--- a/src/Webform/Webform.php
+++ b/src/Webform/Webform.php
@@ -73,7 +73,7 @@ class Webform {
    * @param \Drupal\little_helpers\Webform\Submission $submission
    *   An optional submission object used to replace tokens in the redirect URL.
    *
-   * @return \Drupal\little_helpers\System\FormRedirect
+   * @return array
    *   The form redirect calculated from the webform config and submission.
    */
   public function getRedirect(Submission $submission = NULL) {
@@ -90,7 +90,7 @@ class Webform {
     $redirect_url = preg_replace('/^' . preg_quote($GLOBALS['base_url'], '/') . '\//', '', $redirect_url);
 
     if ($redirect_url == '<none>') {
-      $redirect = FormRedirect(['path' => NULL]);
+      $redirect = new FormRedirect(['path' => NULL]);
     }
     elseif ($redirect_url == '<confirmation>') {
       $options = array();
@@ -100,7 +100,7 @@ class Webform {
           $options['query']['token'] = webform_get_submission_access_token($submission);
         }
       }
-      $redirect = FormRedirect(['path' => "node/{$node->nid}/done"] + $options);
+      $redirect = new FormRedirect(['path' => "node/{$node->nid}/done"] + $options);
     }
     elseif (valid_url($redirect_url, TRUE)) {
       $redirect = FormRedirect::fromFormStateRedirect($redirect_url);
@@ -110,13 +110,13 @@ class Webform {
       if ($submission) {
         $parts['query']['sid'] = $submission->sid;
       }
-      $redirect = FormRedirect($parts);
+      $redirect = new FormRedirect($parts);
     }
     else {
       $redirect = FormRedirect::fromFormStateRedirect($redirect_url);
     }
     drupal_alter('webform_redirect', $redirect, $submission);
-    return $submission;
+    return $redirect->toFormStateRedirect();
   }
 
   /**

--- a/src/Webform/Webform.php
+++ b/src/Webform/Webform.php
@@ -108,17 +108,6 @@ class Webform {
     return $redirect_url;
   }
 
-  public function getRedirectUrl($submission = NULL, $absolute = TRUE) {
-    $redirect = $this->getRedirect($submission);
-    if (is_array($redirect)) {
-      $redirect[1]['absolute'] = $absolute;
-      return url($redirect[0], $redirect[1]);
-    }
-    else {
-      return $redirect;
-    }
-  }
-
   /**
    * Create a submission-object from a webform_client_form $form_state.
    *

--- a/src/Webform/Webform.php
+++ b/src/Webform/Webform.php
@@ -90,7 +90,7 @@ class Webform {
     $redirect_url = preg_replace('/^' . preg_quote($GLOBALS['base_url'], '/') . '\//', '', $redirect_url);
 
     if ($redirect_url == '<none>') {
-      return new FormRedirect(['path' => NULL]);
+      $redirect = FormRedirect(['path' => NULL]);
     }
     elseif ($redirect_url == '<confirmation>') {
       $options = array();
@@ -100,19 +100,23 @@ class Webform {
           $options['query']['token'] = webform_get_submission_access_token($submission);
         }
       }
-      return new FormRedirect(['path' => "node/{$node->nid}/done"] + $options);
+      $redirect = FormRedirect(['path' => "node/{$node->nid}/done"] + $options);
     }
     elseif (valid_url($redirect_url, TRUE)) {
-      return FormRedirect::fromFormStateRedirect($redirect_url);
+      $redirect = FormRedirect::fromFormStateRedirect($redirect_url);
     }
     elseif ($redirect_url && strpos($redirect_url, 'http') !== 0) {
       $parts = drupal_parse_url($redirect_url);
       if ($submission) {
         $parts['query']['sid'] = $submission->sid;
       }
-      return new FormRedirect($parts);
+      $redirect = FormRedirect($parts);
     }
-    return FormRedirect::fromFormStateRedirect($redirect_url);
+    else {
+      $redirect = FormRedirect::fromFormStateRedirect($redirect_url);
+    }
+    drupal_alter('webform_redirect', $redirect, $submission);
+    return $submission;
   }
 
   /**

--- a/tests/Webform/RedirectTest.php
+++ b/tests/Webform/RedirectTest.php
@@ -8,9 +8,9 @@ namespace Drupal\little_helpers\Webform;
 class RedirectTest extends \DrupalUnitTestCase {
 
   /**
-   * Test getting a redirect with an implemented alter-hook.
+   * Generate a submission stub object.
    */
-  public function testGetRedirectWithAlterHook() {
+  protected function submissionStub() {
     $submission = (object) [
       'nid' => 1,
       'sid' => 2,
@@ -22,11 +22,53 @@ class RedirectTest extends \DrupalUnitTestCase {
       'redirect_url' => '<confirmation>',
     ];
     $submission = new Submission((object) $node_array, $submission);
+    $submissions = &drupal_static('webform_get_submission', []);
+    $submissions[$submission->sid] = $submission;
+    return $submission;
+  }
+
+  /**
+   * Test getting a redirect with an implemented alter-hook.
+   */
+  public function testGetRedirectWithAlterHook() {
+    $submission = $this->submissionStub();
     $redirect = $submission->webform->getRedirect($submission);
     unset($redirect[1]['query']['token']);
     $this->assertEqual([
       'node/1/done',
       ['query' => ['test' => 'foo', 'sid' => 2], 'fragment' => 'bar'],
+    ], $redirect);
+  }
+
+  /**
+   * Test altering after a webform submission.
+   */
+  public function testAlterRedirectAfterSubmit() {
+    $submission = $this->submissionStub();
+    $form['#node'] = $submission->node;
+    $form_state['values']['details']['sid'] = 2;
+    $form_state['redirect'] = 'node/1/done';
+    $form_state['webform_completed'] = TRUE;
+    _little_helpers_webform_redirect_alter($form, $form_state);
+    $this->assertEqual([
+      'node/1/done',
+      ['query' => ['test' => 'foo'], 'fragment' => 'bar'],
+    ], $form_state['redirect']);
+  }
+
+  /**
+   * Test altering after returning from a confirmation email.
+   */
+  public function testAlterRedirectAfterConfirmationEmail() {
+    $submission = $this->submissionStub();
+    $redirect = 'https://example.com?bar=baz#test';
+    little_helpers_webform_confirm_email_confirmation_redirect_alter($redirect, $submission->node, $submission);
+    $this->assertEqual([
+      'https://example.com',
+      [
+        'query' => ['test' => 'foo', 'bar' => 'baz'],
+        'fragment' => 'testbar',
+      ],
     ], $redirect);
   }
 

--- a/tests/Webform/RedirectTest.php
+++ b/tests/Webform/RedirectTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\little_helpers\Webform;
+
+/**
+ * Test redirects after a webform submission.
+ */
+class RedirectTest extends \DrupalUnitTestCase {
+
+  /**
+   * Test getting a redirect with an implemented alter-hook.
+   */
+  public function testGetRedirectWithAlterHook() {
+    $submission = (object) [
+      'nid' => 1,
+      'sid' => 2,
+      'data' => [],
+    ];
+    $node_array['nid'] = 1;
+    $node_array['webform'] = [
+      'components' => [],
+      'redirect_url' => '<confirmation>',
+    ];
+    $submission = new Submission((object) $node_array, $submission);
+    $redirect = $submission->webform->getRedirect($submission);
+    unset($redirect[1]['query']['token']);
+    $this->assertEqual([
+      'node/1/done',
+      ['query' => ['test' => 'foo', 'sid' => 2], 'fragment' => 'bar'],
+    ], $redirect);
+  }
+
+}

--- a/webform.api.php
+++ b/webform.api.php
@@ -1,5 +1,8 @@
 <?php
 
+use Drupal\little_helpers\System\FormRedirect;
+use Drupal\little_helpers\Webform\Submission;
+
 /**
  * React when a webform submission is completed and email confirmation is done.
  *
@@ -8,9 +11,21 @@
  *   its first time.
  * - A submission needing email confirmation is confirmed.
  *
- * @param \Drupal\little_helpers\Webform\Submission $submission_o
+ * @param \Drupal\little_helpers\Webform\Submission $submission
  *  The submission just having been confirmed / saved.
  */
 
-function hook_webform_submission_confirmed($submission_o) {
+function hook_webform_submission_confirmed(Submission $submission) {
+}
+
+/**
+ * Alter the URL the user is redirected to after submitting a webform.
+ *
+ * @param \Drupal\little_helpers\System\FormRedirect $redirect
+ *   The redirect to be altered.
+ * @param \Drupal\little_helpers\Webform\Submission $submission
+ *   The submission that is about to be finished.
+ */
+function hook_webform_redirect_alter(FormRedirect &$redirect, Submission $submission = NULL) {
+  $redirect->query['utm_source'] = 'my-tracking-parameter';
 }


### PR DESCRIPTION
This collects all the redirects of:

* webform submissions directly via `webform_client_form_submit()`.
* webform_confirm_email for redirecting after the submission was confirmed.
* webform_paymethod_select when returning from a successful payment.

… and introduces a new `hook_webform_redirect_alter()` to edit all this redirects. Redirects are represented as a `FormRedirect` with a standardized structure.