### PR TITLE
Fix typo in webform_submission_presave().

### DIFF
--- a/little_helpers.module
+++ b/little_helpers.module
@@ -61,7 +61,7 @@ function little_helpers_webform_submission_insert($node, $submission) {
  * @see little_helpers_webform_submission_update() to only invoke the hook once.
  */
 function little_helpers_webform_submission_presave($node, $submission) {
-  $submission->new_or_was_draft = empty($submission->sid) || empty($submission->complete);
+  $submission->new_or_was_draft = empty($submission->sid) || empty($submission->completed);
 }
 
 /**

--- a/little_helpers_test/little_helpers_test.module
+++ b/little_helpers_test/little_helpers_test.module
@@ -15,3 +15,10 @@ function little_helpers_test_webform_redirect_alter(FormRedirect $redirect, Subm
   $redirect->query['test'] = 'foo';
   $redirect->fragment .= 'bar';
 }
+
+/**
+ * Implements hook_webform_submission_confirmed().
+ */
+function little_helpers_test_webform_submission_confirmed(Submission $submission) {
+  $submission->confirmed_hook_called = TRUE;
+}

--- a/tests/Webform/SubmissionIntegrationTest.php
+++ b/tests/Webform/SubmissionIntegrationTest.php
@@ -33,6 +33,14 @@ class SubmissionIntegrationTest extends DrupalUnitTestCase {
   }
 
   /**
+   * Remove the test node.
+   */
+  public function tearDown() {
+    node_delete($this->node->nid);
+    parent::tearDown();
+  }
+
+  /**
    * Test modifying a submission.
    */
   public function testSaveUpdate() {
@@ -57,11 +65,21 @@ class SubmissionIntegrationTest extends DrupalUnitTestCase {
   }
 
   /**
-   * Remove the test node.
+   * Test whether hook_webform_submission_confirmed() is called.
    */
-  public function tearDown() {
-    node_delete($this->node->nid);
-    parent::tearDown();
+  public function testConfirmedHook() {
+    // The submission has been saved as draft so the hook shouldn’t be called.
+    $this->assertFalse(!empty($this->submission->confirmed_hook_called));
+
+    $this->submission->is_draft = FALSE;
+    webform_submission_update($this->node, $this->submission);
+    // First save as non-draft should trigger the confirmed hook.
+    $this->assertTrue(!empty($this->submission->confirmed_hook_called));
+
+    $this->submission->confirmed_hook_called = FALSE;
+    webform_submission_update($this->node, $this->submission);
+    // Saving the submission again shouldn’t called the hook.
+    $this->assertFalse(!empty($this->submission->confirmed_hook_called));
   }
 
 }


### PR DESCRIPTION
This typo led to `hook_webform_submission_confirmed()` to be invoked every time a submission was saved.