### PR TITLE
Submission: No webform_tracking values when querying by form key.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,44 @@
 language: php
+os: linux
+dist: xenial
 services:
   - mysql
 php:
   - 7.3
+branches:
+  only:
+  - 7.x-2.x
+
 mysql:
   database: drupal
   username: root
   encoding: utf8
 
+env:
+  COMPOSER_HOME=$HOME/.config/composer
+
 cache:
   directories:
-     - $HOME/.composer/cache
+     - $COMPOSER_HOME/cache
      - $HOME/.drush/cache
 
 install:
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - composer global require drush/drush:8.1.* torotil/upal:1.2.0 phpunit/phpunit:6.4.*
+  - export PATH="$COMPOSER_HOME/vendor/bin:$PATH"
+  - composer global require drush/drush:8.1.* phpunit/phpunit:^8 torotil/upal:2.0.0-RC1
 
 before_script:
   - repo=`pwd`
   - root=$HOME/test-root
   - mysql -e 'create database drupal'
-  - php -d include_path=`pwd` -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes core-quick-drupal --core=drupal-7.60 --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/drupal --root=$root
+  - php -d include_path=`pwd` -d sendmail_path=`which true` $COMPOSER_HOME/vendor/bin/drush.php --yes core-quick-drupal --core=drupal-7.69 --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/drupal --root=$root
+  - ln -s $repo $root/sites/all/modules/module_under_test
   - cd $root
-  - ln -s $repo sites/all/modules/little_helpers
   - drush dl ctools psr0 views webform
   - drush --yes pm-enable little_helpers little_helpers_test webform
 
 script:
   - cd $repo
-  - UPAL_ROOT=$root UPAL_WEB_URL=http://127.0.0.1 phpunit --bootstrap=$HOME/.composer/vendor/torotil/upal/bootstrap.php --coverage-clover=coverage.xml .
+  - UPAL_ROOT=$root UPAL_WEB_URL=http://127.0.0.1 XDEBUG_MODE=coverage phpunit --bootstrap=$COMPOSER_HOME/vendor/torotil/upal/bootstrap.php --coverage-clover=coverage.xml .
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,6 @@
 <!-- Copy and rename to phpunit.xml. Customize as needed. -->
 <phpunit backupGlobals="false"
-    backupStaticAttributes="false"
-    syntaxCheck="false"
-    strict="true">
+    backupStaticAttributes="false">
 
 <filter>
   <whitelist processUncoveredFilesFromWhitelist="true" addUncoveredFilesFromWhitelist="true">

--- a/src/Webform/Submission.php
+++ b/src/Webform/Submission.php
@@ -92,9 +92,6 @@ class Submission {
     if ($component = &$this->webform->componentByKey($form_key)) {
       return $this->valuesByCid($component['cid']);
     }
-    elseif (isset($this->submission->tracking->$form_key)) {
-      return [$this->submission->tracking->$form_key];
-    }
     return [];
   }
 

--- a/tests/Services/ContainerTest.php
+++ b/tests/Services/ContainerTest.php
@@ -92,11 +92,10 @@ class ContainerTest extends DrupalUnitTestCase {
 
   /**
    * Test loading an unknown service.
-   *
-   * @expectedException \Drupal\little_helpers\Services\UnknownServiceException
    */
   public function testUnknownServiceException() {
     $container = new Container();
+    $this->expectException(UnknownServiceException::class);
     $container->loadService('unknown');
   }
 

--- a/tests/Services/SpecTest.php
+++ b/tests/Services/SpecTest.php
@@ -29,8 +29,6 @@ class SpecTest extends DrupalUnitTestCase {
 
   /**
    * Test exception when keyword argument is not defined.
-   *
-   * @expectedException \Drupal\little_helpers\Services\MissingArgumentException
    */
   public function testKwargsException() {
     $spec = Spec::fromInfo([
@@ -38,6 +36,7 @@ class SpecTest extends DrupalUnitTestCase {
       'constructor' => 'fromArray',
       'arguments' => ['%initial'],
     ]);
+    $this->expectException(MissingArgumentException::class);
     $spec->instantiate();
   }
 

--- a/tests/Webform/FormStateTest.php
+++ b/tests/Webform/FormStateTest.php
@@ -28,7 +28,7 @@ class FormStateTest extends DrupalUnitTestCase {
   /**
    * Enable dependencies, load includes and create a node stub.
    */
-  public function setUp() {
+  public function setUp() : void {
     // Enable any modules required for the test. This should be an array of
     // module names.
     parent::setUp(array('little_helpers'));
@@ -39,7 +39,7 @@ class FormStateTest extends DrupalUnitTestCase {
   /**
    * Remove the node stub.
    */
-  public function tearDown() {
+  public function tearDown() : void {
     node_delete($this->webformNode->nid);
   }
 

--- a/tests/Webform/SubmissionIntegrationTest.php
+++ b/tests/Webform/SubmissionIntegrationTest.php
@@ -12,7 +12,7 @@ class SubmissionIntegrationTest extends DrupalUnitTestCase {
   /**
    * Set up a test node and submission.
    */
-  public function setUp() {
+  public function setUp() : void {
     parent::setUp();
     module_load_include('inc', 'webform', 'includes/webform.submissions');
     $node = (object) ['title' => 'test webform', 'type' => 'webform'];
@@ -35,7 +35,7 @@ class SubmissionIntegrationTest extends DrupalUnitTestCase {
   /**
    * Remove the test node.
    */
-  public function tearDown() {
+  public function tearDown() : void {
     node_delete($this->node->nid);
     parent::tearDown();
   }

--- a/tests/Webform/SubmissionTest.php
+++ b/tests/Webform/SubmissionTest.php
@@ -28,20 +28,6 @@ class SubmissionTest extends DrupalUnitTestCase {
   }
 
   /**
-   * Test getting values from tracking data.
-   */
-  public function testGetValueByKeyFromTracking() {
-    $submission = (object) [
-      'data' => [],
-      'tracking' => (object) ['country' => 'ZZ'],
-    ];
-    $node_array['webform'] = ['components' => []];
-    $submission = new Submission((object) $node_array, $submission);
-    $this->assertEqual(['ZZ'], $submission->valuesByKey('country'));
-    $this->assertEqual('ZZ', $submission->valueByKey('country'));
-  }
-
-  /**
    * Test get value by key from unknown component.
    */
   public function testGetValueByKeyUnknownComponent() {


### PR DESCRIPTION
This removes the implicit fallback to tracking values in `Submission::valuesByKey()` (added with 2092b4fd700c0381002fa716958fda22b867d2b8).

Pro:
- The implicit usage is hard-coded and cant’t be changed.
- Since [#9] & [#10] the tracking variables can also be accessed using `$submission->tracking`.


Con:
- Although most code wasn’t made with this behaviour in mind (and therefore misbehaves) it might be a breaking change for some other code.